### PR TITLE
[asan] suppress the static variable leaks

### DIFF
--- a/syncd/Asan.cpp
+++ b/syncd/Asan.cpp
@@ -3,6 +3,12 @@
 #include <csignal>
 #include <sanitizer/lsan_interface.h>
 
+extern "C" {
+    const char* __lsan_default_suppressions() {
+        return "leak:__static_initialization_and_destruction_0\n";
+    }
+}
+
 static void sigterm_handler(int signo)
 {
     SWSS_LOG_ENTER();


### PR DESCRIPTION
This is to suppress ASAN false positives for static variables.
For example, the ServiceMethodTable::m_slots is sometimes reported as leaked.

ASAN report example:
```c
Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7feb0d3f4647 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55b3be15e430 in declare_static<syncd::ServiceMethodTable::SlotBase, syncd::ServiceMethodTable::Slot, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9> syncd/ServiceMethodTable.cpp:74
    #2 0x55b3be15e430 in declare_static<syncd::ServiceMethodTable::SlotBase, syncd::ServiceMethodTable::Slot, 10> syncd/ServiceMethodTable.cpp:81
    #3 0x55b3be15e430 in __static_initialization_and_destruction_0 syncd/ServiceMethodTable.cpp:85
    #4 0x55b3be15e430 in _GLOBAL__sub_I_ServiceMethodTable.cpp syncd/ServiceMethodTable.cpp:121
```